### PR TITLE
mobi - Handle missing locale language gracefully

### DIFF
--- a/packages/mobi-parser/src/mobiFile.ts
+++ b/packages/mobi-parser/src/mobiFile.ts
@@ -204,7 +204,7 @@ export class MobiFile {
     }
     const { titleOffset, titleLength, localeLanguage, localeRegion } = mobi
     // extend mobiHeader through mobi property, title and language
-    const lang = mobiLang[localeLanguage.toString()]
+    const lang = mobiLang[localeLanguage.toString()] ?? []
     const mobiHeaderExtends: MobiHeaderExtends = {
       title: getString(firstRecord.slice(titleOffset, titleOffset + titleLength)),
       language: lang[localeRegion >> 2] ?? lang[0] ?? 'unknown',


### PR DESCRIPTION
Some files cannot be initialized because they do not have the expected language
[test.mobi.zip](https://github.com/user-attachments/files/22792109/test.mobi.zip)
