### PR TITLE
fix(browser): reject with reader.error

### DIFF
--- a/packages/epub-parser/src/utils.ts
+++ b/packages/epub-parser/src/utils.ts
@@ -49,7 +49,7 @@ export class ZipFile {
             })
         }
         reader.readAsArrayBuffer(file as File)
-        reader.onerror = reject
+        reader.onerror = () => reject(reader.error)
       }
       else {
         const fileToLoad: Uint8Array = typeof file === 'string'


### PR DESCRIPTION
The `onerror` handler receives a `ProgressEvent`. To reject with the actual error, we need to use `reader.error` from inside the onerror handler.