### PR TITLE
Removed trimming of fb2 text nodes

### DIFF
--- a/packages/fb2-parser/src/fb2.ts
+++ b/packages/fb2-parser/src/fb2.ts
@@ -205,7 +205,7 @@ export class Fb2File implements EBookParser {
     const res: string[] = []
     for (const node of sectionNode.children) {
       if (node['#name'] === '__text__') {
-        res.push(node._.trim())
+        res.push(node._);
       }
       else {
         const { tag, isSelfClosing } = transformTagName(node['#name'])


### PR DESCRIPTION
Fixes this issue: https://github.com/hhk-png/lingo-reader/issues/8